### PR TITLE
feat: block-insertion

### DIFF
--- a/docs/adding-ads.md
+++ b/docs/adding-ads.md
@@ -1,6 +1,6 @@
 # Adding Ads for Display in Posts
 
-After you [configure the plugin](configuration.md) to set the number of paragraphs before each ad insertion, and the number of available ad insertions, in the Dashboard go to **Appearance > Widgets** to create the ads themselves. You'll see a number of Inserted Ad Positions as widget areas where you can place widgets. You can set the number of available Inserted Ad Positions in the [plugin options panel](configuration.md). Generally speaking, each Inserted Ad Position widget area should have only one widget in it.
+After you [configure the plugin](configuration.md) to set the number of blocks before each ad insertion, and the number of available ad insertions, in the Dashboard go to **Appearance > Widgets** to create the ads themselves. You'll see a number of Inserted Ad Positions as widget areas where you can place widgets. You can set the number of available Inserted Ad Positions in the [plugin options panel](configuration.md). Generally speaking, each Inserted Ad Position widget area should have only one widget in it.
 
 ## Using ad plugins
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,34 +6,34 @@ After installing the Super Cool Ad Inserter Plugin, a link to the Ad Inserter co
 
 The settings on this page control the placement and number of automatic ad zone insertions.
 
-"**Number of paragraphs before first insertion**": The automatic ad inserter will wait this number of paragraphs before inserting the first ad zone.
+"**Number of blocks before first insertion**": The automatic ad inserter will wait this number of blocks before inserting the first ad zone.
 
-"**Number of paragraphs between insertions**": After the first ad zone has been inserted, the automatic ad inserter will wait this number of paragraphs between inserting each subsequent ad zone.
+"**Number of blocks between insertions**": After the first ad zone has been inserted, the automatic ad inserter will wait this number of blocks between inserting each subsequent ad zone.
 
 "**Number of times the ad should be inserted in a post**": The absolute maximum number of ad zones that can be inserted in any post. This will set the number of Widget Areas available for ads in a post. So if you set it to 6, you'll have 6 Widget areas available for different ads:
 
 ![Widget areas for the scaip plugin](./img/scaip-widgets-panel2.png)
 
-Higher-numbered Inserted Ad Positions may not display in shorter posts. The minimum number of paragraphs needed in a post for all ads to display can be calculated with a simple formula. Using the theme's default settings:
+Higher-numbered Inserted Ad Positions may not display in shorter posts. The minimum number of blocks needed in a post for all ads to display can be calculated with a simple formula. Using the theme's default settings:
 
 ```
-    3   Number of paragraphs between insertions
+    3   Number of blocks between insertions
   x 2   Number of times the ad should be inserted in a post
  -----
-  + 4   Number of paragraphs before first insertion (if greater than number of paragraphs between insertions—otherwise, subtract the difference between the two)
+  + 4   Number of blocks before first insertion (if greater than number of blocks between insertions—otherwise, subtract the difference between the two)
  -----
    10
   + 1   A paragraph is needed after the last ad inserted
  -----
-   11   Minimum number of paragraphs to display all ads
+   11   Minimum number of blocks to display all ads
 ```
 
 Note that you don't have to fill all the available Widget Areas with actual ads. If a position doesn't have any widgets, then it will remain blank on the post page. This provides additional flexibility for placing ads where you want without disrupting the flow of the post content.
 
-Having an ad every three paragraphs until the end of the story might get very annoying to users, so this option allows you to balance the presentation of ads along with the post.
+Having an ad every three blocks until the end of the story might get very annoying to users, so this option allows you to balance the presentation of ads along with the post.
 
-"**Minimum number of paragraphs needed in a post to insert ads**": If a post is very short, placing an ad in the middle of the content can be very annoying to readers. This setting allows you to prevent ads from appearing on posts with fewer paragraphs than the threshold.
+"**Minimum number of blocks needed in a post to insert ads**": If a post is very short, placing an ad in the middle of the content can be very annoying to readers. This setting allows you to prevent ads from appearing on posts with fewer blocks than the threshold.
 
 ## Create the Ads
 
-After you define the number of paragraphs before each ad insertion, you can move on to [add the ads](adding-ads.md) themselves.
+After you define the number of blocks before each ad insertion, you can move on to [add the ads](adding-ads.md) themselves.

--- a/docs/display-settings.md
+++ b/docs/display-settings.md
@@ -1,6 +1,6 @@
 # Ad Display Settings
 
-The Super Cool Ad Inserter provides lots of flexibility in how and where ads are placed within posts. By default, 2 ads will be inserted automatically in a post, beginning 3 paragraphs after the beginning and every 3 paragraphs after that. They will not appear if the post is shorter than 6 paragraphs. You can easily change these default settings for ad automatic insertion in the [Ad Inserter Plugin Options panel](configuration.md).
+The Super Cool Ad Inserter provides lots of flexibility in how and where ads are placed within posts. By default, 2 ads will be inserted automatically in a post, beginning 3 blocks after the beginning and every 3 blocks after that. They will not appear if the post is shorter than 6 blocks. You can easily change these default settings for ad automatic insertion in the [Ad Inserter Plugin Options panel](configuration.md).
 
 ## Prevent Automatic Insertion of Ads in a Post
 
@@ -48,15 +48,15 @@ The full set of shortcode arguments is as follows:
 
 ## Ad Spacing Using Empty Inserted Ad Positions
 
-You can add  Widgets to each and every numbered Inserted Ad Position, and they will display every nth paragraph based on the number of paragraphs you defined in **Plugins** > **Ad Inserter**  [options](configuration.md).
+You can add  Widgets to each and every numbered Inserted Ad Position, and they will display every nth paragraph based on the number of blocks you defined in **Plugins** > **Ad Inserter**  [options](configuration.md).
 
-But sometimes you might want to use the default automatic ad insertion but protect larger blocks of paragraphs from getting interrupted by an ad. Let's say the ads are set to display every 3 paragraphs, which means the first ad will appear 3 paragraphs from the beginning of the post. You can use an empty Inserted Ad Position to reserve that position without displaying an ad. In this case, we'd leave Inserted Ad Position 1 blank:
+But sometimes you might want to use the default automatic ad insertion but protect larger groups of blocks from getting interrupted by an ad. Let's say the ads are set to display every 3 blocks, which means the first ad will appear 3 blocks from the beginning of the post. You can use an empty Inserted Ad Position to reserve that position without displaying an ad. In this case, we'd leave Inserted Ad Position 1 blank:
 
 ![empty Inserted Ad position](./img/scaip-widget-area-empty.png)
 
-Note that we haven't even added an empty Text Widget to this Ad Position, but simply left it as an empty widget area. On the post page, the first ad won't display until after 6 paragraphs:
+Note that we haven't even added an empty Text Widget to this Ad Position, but simply left it as an empty widget area. On the post page, the first ad won't display until after 6 blocks:
 
-![post with six paragraphs before the first ad](./img/scaip-ad-after-six-paras.png)
+![post with six blocks before the first ad](./img/scaip-ad-after-six-paras.png)
 
 ## Developer options
 

--- a/inc/scaip-metaboxes.php
+++ b/inc/scaip-metaboxes.php
@@ -22,7 +22,7 @@ function scaip_how_to_shortcode_callback() {
 	<p>
 		<?php
 			printf(
-				esc_html__( 'By default, %1$s ads will be inserted in a post, beginning %2$s paragraphs after the beginning and every %3$s paragraphs after that. They will not appear if this post is shorter than %4$s paragraphs long.', 'scaip' ),
+				esc_html__( 'By default, %1$s ads will be inserted in a post, beginning %2$s blocks after the beginning and every %3$s paragraphs after that. They will not appear if this post is shorter than %4$s paragraphs long.', 'scaip' ),
 				esc_html( $scaip_repetitions ),
 				esc_html( $scaip_start ),
 				esc_html( $scaip_period ),

--- a/inc/scaip-settings.php
+++ b/inc/scaip-settings.php
@@ -23,10 +23,10 @@ add_action( 'admin_menu', 'scaip_add_admin_menu' );
 function scaip_register_settings() {
 	add_settings_section( 'scaip-settings', 'Control how often the ads appear', 'scaip_settings_section_header', 'scaip' );
 
-	add_settings_field( 'scaip_settings_start', 'Number of paragraphs before first insertion', 'scaip_settings_start', 'scaip', 'scaip-settings' );
-	add_settings_field( 'scaip_settings_period', 'Number of paragraphs between insertions', 'scaip_settings_period', 'scaip', 'scaip-settings' );
+	add_settings_field( 'scaip_settings_start', 'Number of blocks before first insertion', 'scaip_settings_start', 'scaip', 'scaip-settings' );
+	add_settings_field( 'scaip_settings_period', 'Number of blocks between insertions', 'scaip_settings_period', 'scaip', 'scaip-settings' );
 	add_settings_field( 'scaip_settings_repetitions', 'Number of times an ad widget area should be inserted in a post', 'scaip_settings_repetitions', 'scaip', 'scaip-settings' );
-	add_settings_field( 'scaip_settings_min_paragraphs', 'Minimum number of paragraphs needed in a post to insert ads', 'scaip_settings_min_paragraphs', 'scaip', 'scaip-settings' );
+	add_settings_field( 'scaip_settings_min_paragraphs', 'Minimum number of blocks needed in a post to insert ads', 'scaip_settings_min_paragraphs', 'scaip', 'scaip-settings' );
 
 	register_setting( 'scaip-settings', 'scaip_settings_start' );
 	register_setting( 'scaip-settings', 'scaip_settings_period' );
@@ -49,8 +49,8 @@ function scaip_settings_section_header( $args ) {
 }
 
 /**
- * The number of paragraphs before which SCAIP should insert the first shortcode,
- * counted in paragraphs from the beginning of the post.
+ * The number of blocks before which SCAIP should insert the first shortcode,
+ * counted in blocks from the beginning of the post.
  *
  * @param array $args the callback args.
  */
@@ -60,8 +60,8 @@ function scaip_settings_start( $args ) {
 }
 
 /**
- * The number of paragraphs after which SCAIP should insert a shortcode,
- * counted in paragraphs since the last time SCAIP inserted a shortcode.
+ * The number of blocks after which SCAIP should insert a shortcode,
+ * counted in blocks since the last time SCAIP inserted a shortcode.
  *
  * @param array $args the callback args.
  */
@@ -85,7 +85,7 @@ function scaip_settings_repetitions( $args ) {
 }
 
 /**
- * The minimum number of paragraphs in a post required for SCAIP to insert a shortcode in a post.
+ * The minimum number of blocks in a post required for SCAIP to insert a shortcode in a post.
  *
  * @param array $args the callback args.
  */
@@ -94,7 +94,7 @@ function scaip_settings_min_paragraphs( $args ) {
 	echo '<input name="scaip_settings_min_paragraphs" id="scaip_settings_min_paragraphs" type="number" value="' . esc_attr( $min_paragraphs ) . '" />';
 	?>
 	<p>
-		<?php esc_html_e( 'If a post has fewer than this number of paragraphs, ads will not be inserted.','scaip' ); ?>
+		<?php esc_html_e( 'If a post has fewer than this number of blocks, ads will not be inserted.','scaip' ); ?>
 	</p>
 	<?php
 }

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -22,16 +22,7 @@ function scaip_insert_shortcode( $content = '' ) {
 	$inserted_shortcode_index = 1;
 	$block_index              = 1;
 
-	// For certain types of blocks, their innerHTML is not a good representation of the length of their content.
-	// For example, slideshows may have an arbitrary amount of slide content, but only show one slide at a time.
-	// For these blocks, let's ignore their length for purposes of inserting prompts.
-	$length_ignored_blocks = apply_filters(
-		'scaip_length_ignored_blocks',
-		[ 'jetpack/slideshow', 'newspack-blocks/carousel', 'newspack-popups/single-prompt' ]
-	);
-	$parsed_blocks         = parse_blocks( $content );
-
-	$total_length = 0;
+	$parsed_blocks = parse_blocks( $content );
 
 	// Turn classic content into HTML blocks.
 	$parsed_blocks = array_reduce(
@@ -73,34 +64,16 @@ function scaip_insert_shortcode( $content = '' ) {
 		[]
 	);
 
-	// Compute total length of the block-based content.
-	foreach ( $parsed_blocks as $block ) {
-		if ( ! in_array( $block['blockName'], $length_ignored_blocks ) ) {
-			$total_length += strlen( wp_strip_all_tags( $block['innerHTML'] ) );
-		} else {
-			// Give length-ignored blocks a length of 1 so that prompts at 0% can still be inserted before them.
-			$total_length++;
-		}
-	}
-
 	if ( $scaip_minimum_blocks > count( $parsed_blocks ) ) {
 		return $content;
 	}
 
-	$pos    = 0;
 	$output = '';
 
 	foreach ( $parsed_blocks as $block ) {
 		$is_empty = empty( trim( $block['innerHTML'] ) );
 		if ( $is_empty ) {
 			continue;
-		}
-
-		// Regular block content: insert prompts between blocks.
-		if ( ! in_array( $block['blockName'], $length_ignored_blocks ) ) {
-			$pos += strlen( wp_strip_all_tags( $block['innerHTML'] ) );
-		} else {
-			$pos++;
 		}
 
 		if (

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -48,6 +48,11 @@ function scaip_insert_shortcode( $content = '' ) {
 				if ( 0 < $dom_body->length ) {
 					$dom_body_elements = $dom_body->item( 0 )->childNodes;
 					foreach ( $dom_body_elements as $index => $entry ) {
+						// Trim whitespace, including non-breaking space.
+						$text_length = strlen( trim( $entry->textContent, "\xC2\xA0\n" ) );
+						if ( 0 === $text_length ) {
+							continue;
+						}
 						$block_html = $dom->saveHtml( $entry );
 						$blocks[]   = [
 							'blockName'    => 'core/html',

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -25,8 +25,11 @@ function scaip_insert_shortcode( $content = '' ) {
 	// For certain types of blocks, their innerHTML is not a good representation of the length of their content.
 	// For example, slideshows may have an arbitrary amount of slide content, but only show one slide at a time.
 	// For these blocks, let's ignore their length for purposes of inserting prompts.
-	$blacklisted_blocks = [ 'jetpack/slideshow', 'newspack-blocks/carousel', 'newspack-popups/single-prompt' ];
-	$parsed_blocks      = parse_blocks( $content );
+	$length_ignored_blocks = apply_filters(
+		'scaip_length_ignored_blocks',
+		[ 'jetpack/slideshow', 'newspack-blocks/carousel', 'newspack-popups/single-prompt' ]
+	);
+	$parsed_blocks         = parse_blocks( $content );
 
 	$total_length = 0;
 
@@ -67,10 +70,10 @@ function scaip_insert_shortcode( $content = '' ) {
 
 	// Compute total length of the block-based content.
 	foreach ( $parsed_blocks as $block ) {
-		if ( ! in_array( $block['blockName'], $blacklisted_blocks ) ) {
+		if ( ! in_array( $block['blockName'], $length_ignored_blocks ) ) {
 			$total_length += strlen( wp_strip_all_tags( $block['innerHTML'] ) );
 		} else {
-			// Give blacklisted blocks a length of 1 so that prompts at 0% can still be inserted before them.
+			// Give length-ignored blocks a length of 1 so that prompts at 0% can still be inserted before them.
 			$total_length++;
 		}
 	}
@@ -89,7 +92,7 @@ function scaip_insert_shortcode( $content = '' ) {
 		}
 
 		// Regular block content: insert prompts between blocks.
-		if ( ! in_array( $block['blockName'], $blacklisted_blocks ) ) {
+		if ( ! in_array( $block['blockName'], $length_ignored_blocks ) ) {
 			$pos += strlen( wp_strip_all_tags( $block['innerHTML'] ) );
 		} else {
 			$pos++;

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -39,7 +39,8 @@ function scaip_insert_shortcode( $content = '' ) {
 			if ( $is_classic_block && ! $is_empty ) {
 				$classic_content = force_balance_tags( wpautop( $block['innerHTML'] ) ); // Ensure we have paragraph tags and valid HTML.
 				$dom             = new DomDocument();
-				@$dom->loadHTML( $classic_content ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				libxml_use_internal_errors( true );
+				$dom->loadHTML( mb_convert_encoding( $classic_content, 'HTML-ENTITIES', get_bloginfo( 'charset' ) ) );
 				$dom_body = $dom->getElementsByTagName( 'body' );
 				if ( 0 < $dom_body->length ) {
 					$dom_body_elements = $dom_body->item( 0 )->childNodes;
@@ -140,7 +141,7 @@ function scaip_should_insert( $start, $block_index, $insertion_index, $repetitio
 		// First insertion should not take period into account.
 		1 === $insertion_index
 		||
-		0 === ( $block_index + $start ) % $period
+		0 === ( $block_index - $start - 1 ) % $period
 	) );
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #54.

### How to test the changes in this Pull Request:

1. Configure the plugin to use a couple of insertion positions, using the Widgets editor
2. Create two posts - one with block content, another with a single Classic block (as would be the case with pre-block-editor content)
3. Observe that on both posts the SCAIP insertions work as expected
4. Observe that a SCAIP insertion is always between top-level elements (that #54 is irreproducible)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->