### PR TITLE
fix: execute filter before block rendering

### DIFF
--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -188,7 +188,7 @@ function scaip_maybe_insert_shortcode( $content = '' ) {
 
 	return scaip_insert_shortcode( $content );
 }
-add_filter( 'the_content', 'scaip_maybe_insert_shortcode', 10 );
+add_filter( 'the_content', 'scaip_maybe_insert_shortcode', 5 );
 
 /**
  * Remove the scaip_maybe_insert_shortcode filter on the_content when there are blocks
@@ -204,7 +204,7 @@ add_filter( 'the_content', 'scaip_maybe_insert_shortcode', 10 );
  */
 function scaip_maybe_remove_shortcode_inserter( $content ) {
 	if ( function_exists( 'has_block' ) && has_block( 'super-cool-ad-inserter-plugin/scaip-sidebar', $content ) ) {
-		remove_filter( 'the_content', 'scaip_maybe_insert_shortcode', 10 );
+		remove_filter( 'the_content', 'scaip_maybe_insert_shortcode', 5 );
 	}
 
 	return $content;


### PR DESCRIPTION
#65 introduced a new method for parsing blocks for ad insertion. The current content filter is applied with priority `10`, which is executed after block rendering. This results in the `parse_block()` usage to always interpret the blocks as freeform HTML and fail to render blocks like YouTube embeds.

This PR changes priority to `5`, which is prior to block rendering and allows the filter to properly read block attributes on `parse_block()`.