### PR TITLE
feat: filter blocks to be counted on ad insertion

### DIFF
--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -70,7 +70,7 @@ function scaip_insert_shortcode( $content = '' ) {
 
 	$output = '';
 
-	$default_count_blocks = [ 'core/paragraph' ];
+	$blocks_allowing_insertion = array_flip( apply_filters( 'scaip_allowing_insertion_blocks', [ 'core/paragraph' ] ) );
 
 	foreach ( $parsed_blocks as $block ) {
 		$is_empty = empty( trim( $block['innerHTML'] ) );
@@ -78,7 +78,10 @@ function scaip_insert_shortcode( $content = '' ) {
 			continue;
 		}
 
-		if ( true !== apply_filters( 'scaip_count_block', in_array( $block['blockName'], $default_count_blocks, true ), $block ) ) {
+		/**
+		 * Skip insertion if the block is not on the allowing-insertion list.
+		 */
+		if ( ! isset( $blocks_allowing_insertion[ $block['blockName'] ] ) ) {
 			$output .= render_block( $block );
 			continue;
 		}
@@ -96,8 +99,7 @@ function scaip_insert_shortcode( $content = '' ) {
 			$inserted_shortcode_index++;
 		}
 
-		$block_content = render_block( $block );
-		$output       .= $block_content;
+		$output .= render_block( $block );
 		$block_index++;
 	}
 

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -70,9 +70,16 @@ function scaip_insert_shortcode( $content = '' ) {
 
 	$output = '';
 
+	$default_count_blocks = [ 'core/paragraph' ];
+
 	foreach ( $parsed_blocks as $block ) {
 		$is_empty = empty( trim( $block['innerHTML'] ) );
 		if ( $is_empty ) {
+			continue;
+		}
+
+		if ( true !== apply_filters( 'scaip_count_block', in_array( $block['blockName'], $default_count_blocks, true ), $block ) ) {
+			$output .= render_block( $block );
 			continue;
 		}
 


### PR DESCRIPTION
This PR reproduces a behavior prior to #65, which is to count only paragraphs for ad insertion. It also implements a filter to be used for modifying the considered blocks:

```php
/**
 * Add image and heading blocks to the ad inserter step count.
 *
 * @param array $blocks List of block names.
 *
 * @return array List of block names to allow ad insertion from.
 */
function my_scaip_allowed_blocks( $blocks ) {
	$allow_blocks = array(
		'core/image',
		'core/heading',
	);
	return array_merge( $blocks, $allow_blocks );
}
add_filter( 'scaip_allowing_insertion_blocks', 'my_scaip_allowed_blocks' );
```

Related to #69.

## How to test the PR

1. Add a post with different types of blocks
2. Confirm your SCAIP settings
3. Make sure the resulting ad spots are skipping blocks that are not `core/paragraph`.