### PR TITLE
fix: serialize block, allow empty innerHTML and html paragraphs

### DIFF
--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -82,7 +82,7 @@ function scaip_insert_shortcode( $content = '' ) {
 		 * Skip insertion if the block is not on the allowing-insertion list.
 		 */
 		if ( ! isset( $blocks_allowing_insertion[ $block['blockName'] ] ) ) {
-			$output .= render_block( $block );
+			$output .= serialize_block( $block );
 			continue;
 		}
 
@@ -99,7 +99,7 @@ function scaip_insert_shortcode( $content = '' ) {
 			$inserted_shortcode_index++;
 		}
 
-		$output .= render_block( $block );
+		$output .= serialize_block( $block );
 		$block_index++;
 	}
 
@@ -118,11 +118,11 @@ function scaip_generate_shortcode( $index ) {
 /**
  * Should shortcode be inserted?
  *
- * @param number $start Min. index to insert at.
- * @param number $block_index Current block index.
- * @param number $insertion_index Current insertion index.
- * @param number $repetitions Max. no. of insertions.
- * @param number $period Period between insertions.
+ * @param int $start Min. index to insert at.
+ * @param int $block_index Current block index.
+ * @param int $insertion_index Current insertion index.
+ * @param int $repetitions Max. no. of insertions.
+ * @param int $period Period between insertions.
  */
 function scaip_should_insert( $start, $block_index, $insertion_index, $repetitions, $period ) {
 	return ( $start < $block_index

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -87,7 +87,7 @@ function scaip_insert_shortcode( $content = '' ) {
 			isset( $blocks_allowing_insertion['core/paragraph'] ) &&
 			! isset( $blocks_allowing_insertion['core/html'] ) &&
 			'core/html' === $block['blockName'] &&
-			str_starts_with( $block['innerHTML'], '<p' )
+			'<p' === substr( $block['innerHTML'], 0, 2 )
 		) {
 			$skip_blocks_allow_insertion = true;
 		}

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -73,8 +73,12 @@ function scaip_insert_shortcode( $content = '' ) {
 	$blocks_allowing_insertion = array_flip( apply_filters( 'scaip_allowing_insertion_blocks', [ 'core/paragraph' ] ) );
 
 	foreach ( $parsed_blocks as $block ) {
-		$is_empty = empty( trim( $block['innerHTML'] ) );
-		if ( $is_empty ) {
+
+		/**
+		 * Skip insertion for empty paragraphs.
+		 */
+		if ( 'core/paragraph' === $block['blockName'] && empty( trim( $block['innerHTML'] ) ) ) {
+			$output .= serialize_block( $block );
 			continue;
 		}
 

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -77,10 +77,10 @@ function scaip_insert_shortcode( $content = '' ) {
 		/**
 		 * Whether to skip `$blocks_allowing_insertion` check.
 		 */
-		$force_insert = false;
+		$skip_blocks_allow_insertion = false;
 
 		/**
-		 * Force ad insertion for HTML blocks that is wrapped in a paragraph tag
+		 * Force ad insertion for HTML blocks that are wrapped in a paragraph tag
 		 * when 'core/paragraph' is allowed.
 		 */
 		if (
@@ -89,7 +89,7 @@ function scaip_insert_shortcode( $content = '' ) {
 			'core/html' === $block['blockName'] &&
 			str_starts_with( $block['innerHTML'], '<p' )
 		) {
-			$force_insert = true;
+			$skip_blocks_allow_insertion = true;
 		}
 
 		/**
@@ -103,7 +103,7 @@ function scaip_insert_shortcode( $content = '' ) {
 		/**
 		 * Skip insertion if the block is not on the allowing-insertion list.
 		 */
-		if ( false === $force_insert && ! isset( $blocks_allowing_insertion[ $block['blockName'] ] ) ) {
+		if ( false === $skip_blocks_allow_insertion && ! isset( $blocks_allowing_insertion[ $block['blockName'] ] ) ) {
 			$output .= serialize_block( $block );
 			continue;
 		}

--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -75,6 +75,24 @@ function scaip_insert_shortcode( $content = '' ) {
 	foreach ( $parsed_blocks as $block ) {
 
 		/**
+		 * Whether to skip `$blocks_allowing_insertion` check.
+		 */
+		$force_insert = false;
+
+		/**
+		 * Force ad insertion for HTML blocks that is wrapped in a paragraph tag
+		 * when 'core/paragraph' is allowed.
+		 */
+		if (
+			isset( $blocks_allowing_insertion['core/paragraph'] ) &&
+			! isset( $blocks_allowing_insertion['core/html'] ) &&
+			'core/html' === $block['blockName'] &&
+			str_starts_with( $block['innerHTML'], '<p' )
+		) {
+			$force_insert = true;
+		}
+
+		/**
 		 * Skip insertion for empty paragraphs.
 		 */
 		if ( 'core/paragraph' === $block['blockName'] && empty( trim( $block['innerHTML'] ) ) ) {
@@ -85,7 +103,7 @@ function scaip_insert_shortcode( $content = '' ) {
 		/**
 		 * Skip insertion if the block is not on the allowing-insertion list.
 		 */
-		if ( ! isset( $blocks_allowing_insertion[ $block['blockName'] ] ) ) {
+		if ( false === $force_insert && ! isset( $blocks_allowing_insertion[ $block['blockName'] ] ) ) {
 			$output .= serialize_block( $block );
 			continue;
 		}


### PR DESCRIPTION
Since #70 fixed the filter priority, the parsing of blocks is returning rendered blocks prior to when they are expected to be rendered for other filters.

This PR updates the filter result by serializing the parsed block back through `serialize_block()` instead of rendering.

Changing from `render_block()` to `serialize_block()` shouldn't result in any change in the plugin's behavior, instead, avoid unexpected behavior from other plugins that make use of filters to parse blocks.

---

1e031c3e29085a97dcadeeeab9fc3abcb3ed66b5 introduces another fix for the block parsing logic. The current implementation to skip empty HTML into the step count is also stripping it from the `$output`. This check should be stricter and not remove the block from the output. There are blocks, such as the `Homepage Posts` block, that doesn't contain any `innerHTML`  and are later rendered using its other attributes. The current behavior is stripping the block entirely.

To test this fix, create a post with the `Homepage Posts` block. On `master` confirm it is not rendered, check out this branch and confirm it is rendered.

---

Appending another fix here since the latest changes require more fine-tuning. The block restriction implemented by #74 fails to consider `core/html` blocks coming from the classic editor. Currently, they will be skipped entirely and no ads would be displayed. 4ae71df5efe6c0b718537794520291a719c62a08 implements a fix by forcing insertion when a `core/html` block is wrapped in `<p />` and `core/paragraph`s are allowed, which is safe to assume it's virtually a `core/paragraph` block.

To test this fix, install and activate the `Classic Editor` plugin, create a post with multiple paragraphs, visit the post on `master` and observe no SCAIP insertions are placed. Switch to this branch and confirm the expected behavior.