### PR TITLE
fix: insertion logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: |
             composer require "phpunit/phpunit=5.7.*"
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 5.8.1
             ./vendor/bin/phpunit
 
   release_github:


### PR DESCRIPTION
The current insertion logic relies on the next acceptable block to **prepend** the ad. It is expected for the ad to be **appended** to the nth block that matches the calculated step.

This causes unexpected behavior when blocks are skipped from the step count, which is the default behavior for every non-paragraph block. If it's set to start after 2 blocks (paragraphs) and the third block of the post is a heading, the 4th block (3rd paragraph) will be the one prepending the ad, resulting in the ad placed after 3 blocks (2 paragraphs and the heading).

This PR fixes this logic issue by appending the ad to the target block and adjusting the calculations for it.

Closes #69.

### Testing this PR

1. In the `master` branch create a post with the following:
   1. Paragraph
   2. Heading
   3. Paragraph
2. Set your SCAIP to start after 1 paragraph
3. Observe your ad being placed after the Heading
4. Switch to this branch, refresh and confirm the expected behavior

### Testing other scenarios

 - Make sure starting at position 0 works as expected
 - Make sure different combinations of period works as expected