### PR TITLE
Shortcode container and sidebar registration hook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: |
             composer require "phpunit/phpunit=5.7.*"
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
+            bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 5.8.1
             ./vendor/bin/phpunit
 
   release_github:

--- a/inc/scaip-settings.php
+++ b/inc/scaip-settings.php
@@ -94,7 +94,7 @@ function scaip_settings_min_paragraphs( $args ) {
 	echo '<input name="scaip_settings_min_paragraphs" id="scaip_settings_min_paragraphs" type="number" value="' . esc_attr( $min_paragraphs ) . '" />';
 	?>
 	<p>
-		<?php esc_html_e( 'If a post has fewer than this number of blocks, ads will not be inserted.','scaip' ); ?>
+		<?php esc_html_e( 'If a post has fewer than this number of blocks, ads will not be inserted.', 'scaip' ); ?>
 	</p>
 	<?php
 }
@@ -149,18 +149,26 @@ function scaip_admin_page() {
  */
 function scaip_register_sidebars() {
 	$sidebars = get_option( 'scaip_settings_repetitions', 2 );
-	$i = 1;
+	$i        = 1;
+
+	$scaip_disable_sidebars = apply_filters( 'scaip_disable_sidebars', false );
+
+	if ( true === $scaip_disable_sidebars ) {
+		return false;
+	}
 
 	while ( $i <= $sidebars ) {
-		register_sidebar(array(
-			'name' => 'Inserted Ad Position ' . $i,
-			'description' => __( 'Widgets in this sidebar will be automatically inserted into posts. Please do not put more than one widget here.', 'scaip' ),
-			'id' => 'scaip-' . $i,
-			'before_widget' => apply_filters( 'scaip_before_widget', '<aside id="%1$s" class="%2$s clearfix">', $i ),
-			'after_widget' => apply_filters( 'scaip_after_widget', '</aside>', $i ),
-			'before_title' => apply_filters( 'scaip_before_title', '<h5 class="adtitle">', $i ),
-			'after_title' => apply_filters( 'scaip_after_title', '</h5>', $i ),
-		));
+		register_sidebar(
+			array(
+				'name'          => 'Inserted Ad Position ' . $i,
+				'description'   => __( 'Widgets in this sidebar will be automatically inserted into posts. Please do not put more than one widget here.', 'scaip' ),
+				'id'            => 'scaip-' . $i,
+				'before_widget' => apply_filters( 'scaip_before_widget', '<aside id="%1$s" class="%2$s clearfix">', $i ),
+				'after_widget'  => apply_filters( 'scaip_after_widget', '</aside>', $i ),
+				'before_title'  => apply_filters( 'scaip_before_title', '<h5 class="adtitle">', $i ),
+				'after_title'   => apply_filters( 'scaip_after_title', '</h5>', $i ),
+			)
+		);
 		$i++;
 	}
 }

--- a/inc/scaip-shortcode.php
+++ b/inc/scaip-shortcode.php
@@ -5,8 +5,9 @@
 
 /**
  * The SCAIP shortcode function
+ * Outputs an aside 'scaip-#' where # is the 'number' argument on the shortcode.
  *
- * @param Array $atts Shortcode attributes or block properties.
+ * @param Array  $atts Shortcode attributes or block properties.
  * @param String $content Shortcode wrapped text; not used in this shortcode.
  * @param String $tag The complete shortcode tag; not used in this shortcode.
  * @return HTML
@@ -17,17 +18,34 @@ function scaip_shortcode( $atts = array(), $content = '', $tag = '' ) {
 	if ( isset( $atts['no'] ) ) {
 		return '';
 	}
+	
+	if ( ! isset( $atts['number'] ) ) {
+		return '';
+	}
 
 	ob_start();
 	do_action( 'scaip_shortcode', $atts );
-	$ret = ob_get_clean();
-	return $ret;
+	$ad = ob_get_clean();
+
+	if ( empty( trim( $ad ) ) ) {
+		return '';
+	}
+
+	return sprintf(
+		'<aside class="scaip scaip-%1$s %2$s %3$s %4$s %5$s">%6$s</aside>',
+		esc_attr( $atts['number'] ),
+		isset( $atts['align'] ) ? esc_attr( 'align' . $atts['align'] ) : '',
+		isset( $atts['class'] ) ? esc_attr( $atts['class'] ) : '',
+		isset( $atts['className'] ) ? esc_attr( $atts['className'] ) : '',
+		isset( $atts['customClassName'] ) ? esc_attr( $atts['customClassName'] ) : '',
+		$ad
+	);
 }
 add_shortcode( 'scaip', 'scaip_shortcode' );
 add_shortcode( 'ad', 'scaip_shortcode' );
 
 /**
- * Outputs the sidebar 'scaip-#' where # is the 'number' argument on the shortcode.
+ * Outputs the SCAIP sidebar from the shortcode attributes.
  *
  * To prevent this happening, decrease the number of ads that should be inserted to 0, remove the ad widgets form the sidebar, or remove_action('scaip_shortcode', 'scaip_shortcode_do_sidebar');
  *
@@ -35,17 +53,6 @@ add_shortcode( 'ad', 'scaip_shortcode' );
  * @since 0.1
  */
 function scaip_shortcode_do_sidebar( $args ) {
-	if ( isset( $args['number'] ) ) {
-		printf(
-			'<aside class="scaip scaip-%1$s %2$s %3$s %4$s %5$s">',
-			esc_attr( $args['number'] ),
-			( isset( $args['align'] ) ) ? esc_attr( 'align' . $args['align'] ) : '',
-			( isset( $args['class'] ) ) ? esc_attr( $args['class'] ) : '',
-			( isset( $args['className'] ) ) ? esc_attr( $args['className'] ) : '',
-			( isset( $args['customClassName'] ) ) ? esc_attr( $args['customClassName'] ) : ''
-		);
-		dynamic_sidebar( 'scaip-' . esc_attr( $args['number'] ) );
-		echo '</aside>';
-	}
+	dynamic_sidebar( 'scaip-' . esc_attr( $args['number'] ) );
 }
 add_action( 'scaip_shortcode', 'scaip_shortcode_do_sidebar' );

--- a/tests/inc/test-scaip-shortcode.php
+++ b/tests/inc/test-scaip-shortcode.php
@@ -3,7 +3,15 @@
 class ScaipShortcodeTestFunctions extends WP_UnitTestCase {
 
 	function test_scaip_shortcode() {
-		$ret = scaip_shortcode( array( 'number' => 4 ), '', '' );
-		$this->assertRegExp( '/4/', $ret );
+		$scaip_index = 1;
+		$text        = 'Ad ' . $scaip_index;
+		add_action(
+			'scaip_shortcode',
+			function ( $args ) {
+				echo 'Ad ' . esc_attr( $args['number'] );
+			}
+		);
+		$ret = scaip_shortcode( array( 'number' => $scaip_index ), '', '' );
+		$this->assertRegExp( "/{$text}/", $ret );
 	}
 }


### PR DESCRIPTION
This PR improves the extensibility of the plugin:

 - Ensure that inserted ads have a common `<aside />` as container regardless of the action hook applied
 - Allow a different plugin to disable the use of sidebars

If the `scaip_shortcode_do_sidebar()` can be removed to allow other hooks to be injected into `scaip_shortcode`, we should assume that a different placement logic is replacing the sidebar. The sidebar not being useful in this case, it should have the possibility to not be registered.

No changes should take place:

- Make sure ads are being placed with the proper `<aside />` as its container
- Test the `scaip_disable_sidebars` filter by adding `add_filter( 'scaip_disable_sidebars', '__return_true' );` in your theme `functions.php` file and confirming the sidebars are no longer registered on `Appearance -> Widgets`