### PR TITLE
fix: ensure node is empty before stripping from content

### DIFF
--- a/inc/scaip-shortcode-inserter.php
+++ b/inc/scaip-shortcode-inserter.php
@@ -39,10 +39,12 @@ function scaip_insert_shortcode( $content = '' ) {
 				if ( 0 < $dom_body->length ) {
 					$dom_body_elements = $dom_body->item( 0 )->childNodes;
 					foreach ( $dom_body_elements as $index => $entry ) {
-						// Trim whitespace, including non-breaking space.
-						$text_length = strlen( trim( $entry->textContent, "\xC2\xA0\n" ) );
-						if ( 0 === $text_length ) {
-							continue;
+						if ( ! $entry->hasChildNodes() ) {
+							// Trim whitespace, including non-breaking space.
+							$text_length = strlen( trim( $entry->textContent, "\xC2\xA0\n" ) );
+							if ( 0 === $text_length ) {
+								continue;
+							}
 						}
 						$block_html = $dom->saveHtml( $entry );
 						$blocks[]   = [


### PR DESCRIPTION
As pointed out by @tmtrademark in #111:

> When the length of textContent is checked here https://github.com/Automattic/super-cool-ad-inserter-plugin/blob/master/inc/scaip-shortcode-inserter.php#L43, it doesn't account for the fact that `<img>` tags can and do get wrapped in `<p>` tags. So the enclosing `<p>` tags textContent is empty, making $text_length zero, so the node is skipped and not added back to $blocks.

This PR makes sure to check if the node has child nodes before checking for `textContent` length.

This issue does not occur with Newspack Campaigns active because the plugin transforms classic content into blocks before reaching SCAIP.

Closes #73
Closes #111

## How to test

1. Install and enable the Classic Editor plugin
2. On the master branch make sure you don't have other plugins interfering with block content configuration (Newspack Campaigns)
3. Add a new post with multiple paragraphs and a `<p><img src="" /></p>`
4. Confirm the image does not render
5. Check out this branch and confirm the image renders as expected