### PR TITLE
fix: save "prevent shortcode" meta

### DIFF
--- a/inc/scaip-metaboxes.php
+++ b/inc/scaip-metaboxes.php
@@ -94,7 +94,7 @@ function _scaip_meta_box_save( $post_id, $post ) {
 	}
 
 	// If our current user can't edit this post, bail.
-	if ( ! current_user_can( 'edit_post' ) ) {
+	if ( ! current_user_can( 'edit_post', $post->ID ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes a bug preventing the "Prevent automatic addition of ads to this post." checkbox to be saved.

### How to test

1. While on master, edit a post, check the checkbox and save
2. Refresh the page and confirm the value is not saved
3. Check out this branch and try again
4. Confirm the value is saved